### PR TITLE
Upgrade Python in GitHub Actions to 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/melpazoid.yml
+++ b/melpazoid.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
-      with: { python-version: 3.6 }
+      with: { python-version: 3.9 }
     - name: Install
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
[actions/setup-python](https://github.com/actions/setup-python) no longer supports Python 3.6 (https://github.com/actions/setup-python/issues/561).

So running the suggested CI config now fails like that:
```
Run actions/setup-python@v1
  with:
    python-version: 3.6
    architecture: x64
Error: Version 3.6 with arch x64 not found
Available versions:

3.10.8 (x64)
3.11.0 (x64)
3.7.15 (x64)
3.8.15 (x64)
3.9.15 (x64)
```

I've upgraded the Python version to 3.9, and it seems to work fine.