### PR TITLE
Update Python

### DIFF
--- a/melpazoid.yml
+++ b/melpazoid.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.11.0
       uses: actions/setup-python@v1
-      with: { python-version: 3.6 }
+      with: { python-version: 3.11.0 }
     - name: Install
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Python 3.6 seems to not be supported by GitHub anymore. Using the YAML workflow resulted in this error: https://github.com/tinloaf/org-incoming/actions/runs/3679726954/jobs/6224516996#step:3:6

Updating to Python 3.11.0 (the most recent version available) fixed the error for me.