### PR TITLE
Fix "progress=plain and quiet cannot be used together" in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ term: image
 
 .PHONY: image
 image:
-	@$(DOCKER) build --build-arg PACKAGE_MAIN --progress=plain --quiet \
+	@$(DOCKER) build --build-arg PACKAGE_MAIN --quiet \
 		--tag ${IMAGE_NAME} -f docker/Dockerfile .
 
 .PHONY: test-melpazoid


### PR DESCRIPTION
As of now, the CI gives the following error:
```
ERROR: progress=plain and quiet cannot be used together
make[1]: *** [Makefile:20: image] Error 1
```

E.g. [an action log with this error](https://github.com/SqrtMinusOne/elfeed-summary/actions/runs/5949515191/job/16135450266). Removing `--progress=plain` seems to fix that.