### PR TITLE
make: add --load to fix new build options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ IMAGE_NAME = melpazoid
 DOCKER ?= docker
 DOCKER_OPTIONS = --cap-drop all --security-opt=no-new-privileges --pids-limit=5
 DOCKER_OUTPUT = --quiet  # e.g. '--progress=plain' xor '--quiet'
+BUILD_OPTIONS = --load
 
 .PHONY: run
 run:
@@ -18,7 +19,7 @@ term: image
 
 .PHONY: image
 image:
-	@$(DOCKER) build --build-arg PACKAGE_MAIN ${DOCKER_OUTPUT} \
+	@$(DOCKER) build --build-arg PACKAGE_MAIN ${BUILD_OPTIONS} ${DOCKER_OUTPUT} \
 		--tag ${IMAGE_NAME} -f docker/Dockerfile .
 
 .PHONY: test-melpazoid


### PR DESCRIPTION
This is one of those things I don't understand but it seems that newer
docker and podman build containers using a different method and by
adding this option it fixes certain build errors and doesn't seem to
harm existing CI.

If this isn't the right way to do, just lemme know and I'll update it!