### PR TITLE
Support external dependencies (and emacs-vterm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _requirements.el
 _reminders.json
+_native_deps
 pkg
 *.elc
 

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ term: image
 	$(DOCKER) run -it --rm --entrypoint=/bin/bash ${DOCKER_OPTIONS} ${IMAGE_NAME}
 
 .PHONY: image
-image:
-	@$(DOCKER) build --build-arg PACKAGE_MAIN ${DOCKER_OUTPUT} \
+image: _requirements.el _native_deps
+	@$(DOCKER) build --build-arg NATIVE_DEPS="$$(cat _native_deps)" --build-arg PACKAGE_MAIN ${DOCKER_OUTPUT} \
 		--tag ${IMAGE_NAME} -f docker/Dockerfile .
 
 .PHONY: test-melpazoid

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,10 @@
 # <https://ubuntuhandbook.org/index.php/2023/08/gnu-emacs-29-1-ubuntu-ppa/>
 FROM ubuntu:22.04
 
+ARG NATIVE_DEPS=""
+ENV NATIVE_DEPS="${NATIVE_DEPS}"
 RUN apt-get update \
-        && apt-get -y install curl gnupg openssh-client wget \
+        && apt-get -y install curl gnupg openssh-client wget ${NATIVE_DEPS} \
         && apt-get -y --no-install-recommends install software-properties-common \
         && add-apt-repository ppa:ubuntuhandbook1/emacs \
         && apt-get -y install emacs emacs-common \

--- a/melpazoid/melpazoid.py
+++ b/melpazoid/melpazoid.py
@@ -266,7 +266,6 @@ def _write_requirements(files: list[Path]) -> None:
                 _fail(
                     "- Don't require marginalia: https://github.com/minad/marginalia#adding-custom-annotators-or-classifiers"
                 )
-
             # always install the latest available version of the dependency.
             requirements_el.write(
                 f'\n(message "Installing {req_} {version} or later")\n'

--- a/melpazoid/melpazoid.py
+++ b/melpazoid/melpazoid.py
@@ -238,7 +238,8 @@ def _main_file(files: list[Path], recipe: str) -> Path | None:
 
 def _write_requirements(files: list[Path]) -> None:
     """Create a little elisp script that Docker will run as setup."""
-    with Path('_requirements.el').open('w', encoding='utf-8') as requirements_el:
+    with (Path('_requirements.el').open('w', encoding='utf-8') as requirements_el,
+          Path('_native_deps').open('w', encoding='utf-8') as native_deps):
         requirements_el.write(
             f";; {time.strftime('%Y-%m-%d')} ; helps to invalidate old Docker cache\n\n"
             + ";; NOTE: emacs --script <file.el> will set `load-file-name' to <file.el>\n"
@@ -265,11 +266,17 @@ def _write_requirements(files: list[Path]) -> None:
                 _fail(
                     "- Don't require marginalia: https://github.com/minad/marginalia#adding-custom-annotators-or-classifiers"
                 )
+
             # always install the latest available version of the dependency.
             requirements_el.write(
                 f'\n(message "Installing {req_} {version} or later")\n'
                 + f"(ignore-errors (package-install (cadr (assq '{req_} package-archive-contents))))\n"
             )
+
+            if req == 'vterm':
+                native_deps.write("cmake libvterm-dev ")
+                requirements_el.write('(setq vterm-always-compile-module t)\n')
+                requirements_el.write('(vterm-module-compile)\n')
 
 
 def requirements(files: list[Path]) -> set[str]:

--- a/melpazoid/melpazoid.py
+++ b/melpazoid/melpazoid.py
@@ -238,8 +238,10 @@ def _main_file(files: list[Path], recipe: str) -> Path | None:
 
 def _write_requirements(files: list[Path]) -> None:
     """Create a little elisp script that Docker will run as setup."""
-    with (Path('_requirements.el').open('w', encoding='utf-8') as requirements_el,
-          Path('_native_deps').open('w', encoding='utf-8') as native_deps):
+    with (
+        Path('_requirements.el').open('w', encoding='utf-8') as requirements_el,
+        Path('_native_deps').open('w', encoding='utf-8') as native_deps
+    ):
         requirements_el.write(
             f";; {time.strftime('%Y-%m-%d')} ; helps to invalidate old Docker cache\n\n"
             + ";; NOTE: emacs --script <file.el> will set `load-file-name' to <file.el>\n"


### PR DESCRIPTION
This modifies melpazoid.py to generate an extra file with native dependencies that are installed with apt-get when the docker image is built.

The motivation for this is to support emacs-vterm and it's natively compiled module.
Maybe I'm overlooking something and this is overkill :).

