### PR TITLE
specify :fetcher before :repo in melpazoid.yml

### DIFF
--- a/melpazoid.yml
+++ b/melpazoid.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         LOCAL_REPO: ${{ github.workspace }}
         # RECIPE is your recipe as written for MELPA:
-        RECIPE: (shx :repo "riscy/shx-for-emacs" :fetcher github)
+        RECIPE: (shx :fetcher github :repo "riscy/shx-for-emacs")
         # set this to false (or remove it) if the package isn't on MELPA:
         EXIST_OK: true
       run: echo $GITHUB_REF && make -C ~/melpazoid


### PR DESCRIPTION
Hey! I got the following warning when I copied over the sample melpazoid.yml:
```
Please specify `:fetcher` before `:repo` in your recipe
```

Super simple to address on my end of course, but I think it'll probably be a little bit more ergonomic for new users if the sample follows the convention by default.

Thanks for creating melpazoid!