### PR TITLE
Use more standard file:line:column: in warnings

### DIFF
--- a/melpazoid/melpazoid.el
+++ b/melpazoid/melpazoid.el
@@ -399,9 +399,10 @@ CASE-INSENSITIVE determines the case-sensitivity of the matches."
 
 (defun melpazoid--annotate-line (msg)
   "Annotate the current line with MSG."
-  (melpazoid-insert "- %s#L%s: %s"
+  (melpazoid-insert "- %s:%s:%s: %s"
                     (file-name-nondirectory (buffer-file-name))
                     (line-number-at-pos)
+                    (1+ (- (point) (line-beginning-position)))
                     msg))
 
 (defun melpazoid-insert (f-str &rest objects)


### PR DESCRIPTION
Use more conventional format for warnings (matching clang/GCC for example),
this means tools that scan for warnings from linters are more likely to be able to parse the warnings.

----

I have my terminal configured so warnings are clickable and load in the editor,
with this change output from melpazoid can be more conveniently checked.